### PR TITLE
Add missing annotation @TestConfiguration

### DIFF
--- a/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBindingPostProcessorTests.java
+++ b/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBindingPostProcessorTests.java
@@ -45,7 +45,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
-
+import org.springframework.boot.test.context.TestConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
@@ -56,6 +56,7 @@ import static org.junit.Assert.fail;
  * @author Phillip Webb
  * @author Stephane Nicoll
  */
+@TestConfiguration
 public class ConfigurationPropertiesBindingPostProcessorTests {
 
 	@Rule


### PR DESCRIPTION
The @TestConfiguration annotation is a useful aid for writing unit tests of components in a Spring Boot application. So it is better to add @TestConfiguration here.